### PR TITLE
Fix randInt

### DIFF
--- a/pitybas/tokens.py
+++ b/pitybas/tokens.py
@@ -652,6 +652,9 @@ class randInt(MathFunction):
         if len(args) == 2:
             args.append(1)
 
+        if args[0] > args[1]:
+            args[0], args[1] = args[1], args[0]
+
         return [random.randint(*args[:2]) for i in xrange(args[2])]
 
 class randNorm(MathFunction):


### PR DESCRIPTION
Fixes randInt
Python's random.randint only takes two arguments, not three
and TIBasic's randInt works even when min > max.
